### PR TITLE
ref(sdk): Update to be compatible with Sentry SDK v7

### DIFF
--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -178,9 +178,9 @@ function createEnvironment({ baseEnvironment } = {}) {
             beforeFinish: (span) => {
               const parent = this.testContainers.get(this.getName(event.test));
               if (parent && !Array.isArray(parent)) {
-                return parent.child(span);
+                return parent.startChild(span);
               } else if (Array.isArray(parent)) {
-                return parent.find(isNotTransaction).child(span);
+                return parent.find(isNotTransaction).startChild(span);
               }
               return span;
             },
@@ -241,11 +241,9 @@ function createEnvironment({ baseEnvironment } = {}) {
               ? parentStore
                   .get(parentName)
                   .map((s) =>
-                    typeof s.child === "function"
-                      ? s.child(spanProps)
-                      : s.startChild(spanProps)
+                    s.startChild(spanProps
                   )
-              : [parentStore.get(parentName).child(spanProps)]
+              : [parentStore.get(parentName).startChild(spanProps)]
             : [this.transaction.startChild(spanProps)];
 
         spans.push(...span);


### PR DESCRIPTION
It looks like we were using a deprecated 'child()' syntax, see https://github.com/getsentry/sentry-javascript/pull/4849.

Didn't run it as of yet, it _looks_ like a straightforward replacement but I'm not sure why we were using `child` in the first place, so want some eyes on it.

Pretty sure this is the source of errors on https://github.com/getsentry/sentry/pull/34286.