### PR TITLE
fix: clone sentryConfig before mutation

### DIFF
--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -18,7 +18,7 @@ function createEnvironment({baseEnvironment} = {}) {
 
       const [config, context] = args;
 
-      this.options = config.projectConfig.testEnvironmentOptions?.sentryConfig;
+      this.options = structuredClone(config.projectConfig.testEnvironmentOptions?.sentryConfig)
 
       if (
         !this.options ||


### PR DESCRIPTION
Fixes the crash discovered in https://github.com/getsentry/sentry/pull/110568: Sentry's Jest unit tests normally run in worker processes. Modifying the shared config object in them is fine because they're already copies of the original. But when switching to in-band, the environment needs to manually copy them.