### PR TITLE
fix: correct upstream url org to getsentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/billyvg/jest-sentry-environment.git"
+    "url": "git+https://github.com/getsentry/jest-sentry-environment.git"
   },
   "files": [
     "package.json",
@@ -29,9 +29,9 @@
   "author": "Billy Vong <github@mmo.me>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/billyvg/jest-sentry-environment/issues"
+    "url": "https://github.com/getsentry/jest-sentry-environment/issues"
   },
-  "homepage": "https://github.com/billyvg/jest-sentry-environment#readme",
+  "homepage": "https://github.com/getsentry/jest-sentry-environment#readme",
   "devDependencies": {
     "prettier": "^2.3.2"
   },


### PR DESCRIPTION
This repo may have been a fork to start, but it's the real place we work on now. 